### PR TITLE
Add aruco pose reporting node

### DIFF
--- a/cr17/CMakeLists.txt
+++ b/cr17/CMakeLists.txt
@@ -201,9 +201,15 @@ endif()
 include_directories(include ${catkin_INCLUDE_DIRS})
 add_executable(transform_inverter src/transform_inverter.cpp)
 target_link_libraries(transform_inverter ${catkin_LIBRARIES})
+
 add_executable(turtle_teleop_joy src/turtle_teleop_joy.cpp)
 target_link_libraries(turtle_teleop_joy ${catkin_LIBRARIES})
+
 add_executable(plane_detector src/plane_detector.cpp)
 target_link_libraries(plane_detector ${catkin_LIBRARIES})
 
 #add_dependencies(transform_inverter )
+
+# Build aruco pose publisher
+add_executable(aruco_pose src/aruco_pose_reporter.cpp)
+target_link_libraries(aruco_pose ${catkin_LIBRARIES})

--- a/cr17/launch/aruco.launch
+++ b/cr17/launch/aruco.launch
@@ -4,23 +4,28 @@
 		 Rather, include it in the main launch file 
 		 and launch that file.  -->
 
-	<arg name="rear_camera" />
-	<arg name="marker_size" />
+	<!-- 
+	camera namespace
+	contains image_raw and camera_info
+	MUST BE RECTIFIED!
+	-->
+	<arg name="camera_ns" />
+
+	<!-- aruco configs -->
 	<arg name="board_directory" />
 	<arg name="boards_config" />
 
-	<arg name="intraboard_transform" />
-	<arg name="world_to_bigBoard_transform" />
-	<arg name="transform_topic" />
+	<!-- frame configs for pose estimate -->
+	<arg name="world_frame" />
+	<arg name="target_frame" />
 
 	<node pkg="ar_sys" type="multi_boards" name="ar_multi_board">
 
 		<!-- May need tweaking based on kinect/realsense -->
-		<remap from="/camera_info" to="$(arg rear_camera)/rgb/camera_info" />
-		<remap from="/image" to="$(arg rear_camera)/rgb/image_raw" />
+		<remap from="/camera_info" to="$(arg rear_camera)/camera_info" />
+		<remap from="/image" to="$(arg rear_camera)/image_raw" />
 
 		<param name="image_is_rectified" type="bool" value="true"/>
-		<param name="marker_size" type="double" value="$(arg marker_size)"/>
 
 		<param name="boards_config" type="string" value="$(arg boards_config)" />
 
@@ -31,13 +36,11 @@
 		<param name="draw_markers_axis" type="bool" value="false" />
 	</node>
 
-	<node pkg="cr17" type="aruco_transform_broadcaster.py" name="aruco_transformer" >
-		<param name="transform_topic" type="string" value="$(arg transform_topic" />
+	<node pkg="cr17" type="aruco_pose" name="aruco_pose">
+		<param name="transform_topic" value="ar_multi_board/transform" />
+		<param name="pose_topic" value="pose_estimate" />
+		<param name="world_frame" value="$(arg world_frame)" />
+		<param name="target_frame" value="$(arg target_frame)" />
 	</node>
-
-	<node pkg="tf" type="static_transform_publisher" name="TF_big_to_lil_board" args="$(arg intraboard_transform)" />
-
-	<node pkg="tf" type="static_transform_publisher" name="TF_world_to_bigBoard" args="$(arg world_to_bigBoard_transform)" />
-
 
 </launch>

--- a/cr17/launch/robot_main.launch
+++ b/cr17/launch/robot_main.launch
@@ -28,13 +28,11 @@
 	<!-- Launches aruco stack -->
 	<include file="$(find cr17)/launch/aruco.launch" >
 		<!-- aruco parameters -->
-		<arg name="rear_camera" default="/camera" />
-		<arg name="marker_size" default="0.19685" />
+		<arg name="camera" default="/rear_kinect/rgb" />
 		<arg name="board_directory" default="$(find cr17)/param" />
 		<arg name="boards_config" default="$(find cr17)/param/boardsConfiguration.yml" />
-		<arg name="intraboard_transform" default="0 -0.231775 0 0 0 0 1 /bigBoard /lilBoard 100" />
-		<arg name="world_to_bigBoard_transform" default="0 0 0 0 0.7071067811865475 0.7071067811865475 0 /bigBoard /world 100" />		
-		<arg name="transform_topic" default="/ar_multi_board/transform" />
+		<arg name="world_frame" default="world" />
+		<arg name="target_frame" default="base_link"/>
 	</include>
 
 	<!--Launch the nodes used for autonomy -->

--- a/cr17/src/aruco_pose_reporter.cpp
+++ b/cr17/src/aruco_pose_reporter.cpp
@@ -1,0 +1,106 @@
+// Inverts and republishes the pose output by aruco
+// Inversion is needed as aruco outputs pose of the board
+// with respect to the camera.
+// Pose is published in the camera frame
+
+#include "ros/ros.h"
+#include "geometry_msgs/TransformStamped.h"
+#include "geometry_msgs/PoseStamped.h"
+#include "geometry_msgs/PoseWithCovarianceStamped.h"
+#include "tf/transform_datatypes.h"
+
+#include <tf/transform_listener.h>
+
+#include <string>
+
+class PoseReporter{
+
+public:
+
+  ros::NodeHandle n_;
+  ros::NodeHandle n;
+  ros::Publisher pose_pub_;
+  ros::Subscriber transform_sub_;
+  
+  tf::TransformListener listener;
+
+  std::string subscriber_topic;
+  std::string publisher_topic;
+  std::string target_frame;
+  std::string world_frame;
+
+  PoseReporter() : 
+  n_("~"),
+  n()
+  {
+    if (!n_.getParam("transform_topic", subscriber_topic)){
+        ROS_ERROR("Failed to get param 'transform_topic'");
+    } else if (!n_.getParam("pose_topic", publisher_topic)){
+        ROS_ERROR("Failed to get param 'pose_topic'");
+    } else if (!n_.getParam("target_frame", target_frame)){
+        ROS_ERROR("Failed to get param 'target_frame'");
+    } else if (!n_.getParam("world_frame", world_frame)){
+        ROS_ERROR("Failed to get param 'world_frame'");
+    }else {
+
+      // publisher for pose with covariance stamped
+      pose_pub_ = n_.advertise<geometry_msgs::PoseWithCovarianceStamped>(publisher_topic, 1);
+      // subscriber to the transform from aruco
+      transform_sub_ = n.subscribe(subscriber_topic, 1, &PoseReporter::transformCallback, this);
+    }
+  }
+
+  void transformCallback (const geometry_msgs::TransformStamped::ConstPtr& msg)
+  {
+    // msg: camera->board
+    tf::StampedTransform sT;
+    geometry_msgs::PoseStamped pose;
+    geometry_msgs::PoseWithCovarianceStamped new_msg;
+    tf::StampedTransform camera_to_target_transform;
+    tf::StampedTransform world_to_board_transform;
+
+    try{
+      // world->board
+      listener.lookupTransform(world_frame, msg->child_frame_id, ros::Time(0), world_to_board_transform);
+      
+      // camera->target_frame
+      listener.lookupTransform(msg->header.frame_id, target_frame, ros::Time(0), camera_to_target_transform);
+      
+    } catch (tf::TransformException ex) {
+      ROS_ERROR("Transforms unavailable!\n%s", ex.what());
+      ROS_INFO("world: %s", world_frame.c_str());
+      ROS_INFO("target: %s", target_frame.c_str());
+
+    }
+
+    // Convert to a transform: board->camera
+    tf::transformStampedMsgToTF(*msg, sT);
+    // world->board * board->camera * camera->target_frame
+    tf::Transform transform = world_to_board_transform * sT.inverse() * camera_to_target_transform;
+    // Invert to board->camera
+    tf::Stamped<tf::Transform> tf_pose(transform, sT.stamp_, world_frame);
+    // Convert to pose
+    tf::poseStampedTFToMsg (tf_pose, pose);
+
+    new_msg.pose.covariance[0] = -1;
+    new_msg.header = pose.header;
+    new_msg.pose.pose = pose.pose;
+
+    pose_pub_.publish(new_msg);
+
+  }
+
+};
+
+int main(int argc, char** argv)
+{
+  
+  ros::init(argc, argv, "transform_inverter");
+  ROS_INFO("Started node");
+  PoseReporter inverter;
+  ROS_INFO("Started class");
+  ros::spin();
+  ROS_INFO("Exiting");
+  
+  return 0;
+}


### PR DESCRIPTION
Created node for Aruco data processing. The node takes TransformStamped messages published by the ar_sys multi-board node and combines it with tf data to create a pose estimate of where the target_frame resides in the world_frame.